### PR TITLE
Fix: PHP Warnings on PHP 8 with WP-CLI #23

### DIFF
--- a/woocommerce-gateway-cardknox.php
+++ b/woocommerce-gateway-cardknox.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'WC_Cardknox' ) ) :
 		 *
 		 * @return void
 		 */
-		private function __wakeup() {}
+		public function __wakeup() {}
 
 		/**
 		 * Flag to indicate whether or not we need to load code for / support subscriptions.


### PR DESCRIPTION
The purpose of this PR is to fix  PHP Warnings on PHP 8 with the WP-CLI issue.