### PR TITLE
change the paramete no

### DIFF
--- a/includes/class-wc-gateway-cardknox-addons.php
+++ b/includes/class-wc-gateway-cardknox-addons.php
@@ -39,7 +39,7 @@ class WC_Gateway_Cardknox_Addons extends WC_Gateway_Cardknox
         parent::__construct();
 
         if (class_exists('WC_Subscriptions_Order')) {
-            add_action('woocommerce_scheduled_subscription_payment_' . $this->id, array($this, 'scheduled_subscription_payment'), 10, 2);
+            add_action('woocommerce_scheduled_subscription_payment_' . $this->id, array($this, 'scheduled_subscription_payment'), 10, 3);
             add_action('wcs_resubscribe_order_created', array($this, 'delete_resubscribe_meta'), 10);
             add_action('wcs_renewal_order_created', array($this, 'delete_renewal_meta'), 10);
             add_action('woocommerce_subscription_failing_payment_method_updated_cardknox', array($this, 'update_failing_payment_method'), 10, 2);


### PR DESCRIPTION
change the parameter no, in  'class-wc-gateway-cardknox-addons.php' file.
the file path is : /home/plugincardknox/public_html/demo/wpdemo/wp-content/plugins/woocommerce-gateway-cardknox/includes

![order-detail-page](https://github.com/user-attachments/assets/510f8f5d-e4a2-47e5-aad9-05bcb82ba56f)
