### PR TITLE
PHP 8.x Compliance

### DIFF
--- a/includes/class-wc-gateway-cardknox-applepay.php
+++ b/includes/class-wc-gateway-cardknox-applepay.php
@@ -11,7 +11,18 @@ include_once 'settings-cardknox-applepay.php';
  */
 class WCCardknoxApplepay extends WC_Payment_Gateway_CC
 {
-    /**
+
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $applepay_merchant_identifier;
+	public $applepay_environment;
+	public $applepay_button_style;
+	public $applepay_button_type;
+	public $authonly_status;
+	public $applepay_applicable_countries;
+	public $applepay_specific_countries;
+	public $wcVersion;
+
+	/**
      * Should we capture Credit cards
      *
      * @var bool

--- a/includes/class-wc-gateway-cardknox.php
+++ b/includes/class-wc-gateway-cardknox.php
@@ -27,6 +27,9 @@ include_once 'settings-cardknox.php';
 class WC_Gateway_Cardknox extends WC_Payment_Gateway_CC
 {
 
+	/* Define props to avoid php 8.x dynamic prop deprecation warnings. */
+	public $bgcolor;
+
     /**
      * Should we capture Credit cards
      *


### PR DESCRIPTION
[PHP has deprecated dynamic class props](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties).

Warning messages show up in the php error log. e.g.
```
Creation of dynamic property WCCardknoxApplepay::$applepay_button_style is deprecated in /var/www/html/wp-content/plugins/woo-cardknox-gateway/includes/class-wc-gateway-cardknox-applepay.php on line 78
```
This PR will prevent these warning messages.

**Steps to Reproduce**

- Access the cart page.

**Expected Result**

Clean php error log.

**Applies to any instance running PHP 8.2 and up**

**To Solve the problem for all installations**

