### PR TITLE
PLGN-167 - Update ifield version for Woo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## changelog for version Version: 1.2.73
+
+- Updated iFields latest version 3.0.2503.2101
+
 ## changelog for version Version: 1.2.72
 
 - Apple Pay Default Enable - No.

--- a/includes/class-wc-gateway-cardknox-googlepay.php
+++ b/includes/class-wc-gateway-cardknox-googlepay.php
@@ -561,7 +561,7 @@ class WCCardknoxGooglepay extends WC_Payment_Gateway_CC
                 <div class="message message-error error gpay-error" style="display: none;"></div>
             </div>
             <div id="divGpay" class="gp hidden">
-                <iframe id="igp" class="gp" data-ifields-id="igp" data-ifields-oninit="gpRequest.initGP" src="https://cdn.cardknox.com/ifields/2.15.2405.1601/igp.htm" allowpaymentrequest sandbox="allow-popups allow-modals allow-scripts allow-same-origin
+                <iframe id="igp" class="gp" data-ifields-id="igp" data-ifields-oninit="gpRequest.initGP" src="https://cdn.cardknox.com/ifields/3.0.2503.2101/igp.htm" allowpaymentrequest sandbox="allow-popups allow-modals allow-scripts allow-same-origin
                                  allow-forms allow-popups-to-escape-sandbox allow-top-navigation" title="GPay checkout page">
                 </iframe>
             </div>

--- a/includes/class-wc-gateway-cardknox.php
+++ b/includes/class-wc-gateway-cardknox.php
@@ -142,7 +142,7 @@ class WC_Gateway_Cardknox extends WC_Payment_Gateway_CC
         $cvc_field = '<p class="form-row form-row-last">
 			<label for="' . esc_attr($this->id) . '-card-cvc">' . esc_html__('Card Code', 'woocommerce') . ' <span class="required">*</span></label>
 			<iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
-                        src="https://cdn.cardknox.com/ifields/2.15.2405.1601/ifield.htm?" + "' . esc_attr($timestamp) . '" frameBorder="0" width="100%"
+                        src="https://cdn.cardknox.com/ifields/3.0.2503.2101/ifield.htm?" + "' . esc_attr($timestamp) . '" frameBorder="0" width="100%"
                         height="55" id="cvv-frame"></iframe>
             <label data-ifields-id="card-data-error" style="color: red;"></label>
 		</p><input data-ifields-id="cvv-token" name="xCVV" id="cardknox-card-cvc" type="hidden"/>';
@@ -153,7 +153,7 @@ class WC_Gateway_Cardknox extends WC_Payment_Gateway_CC
 				<label style="margin:0px !important; line-height: inherit;" for="' . esc_attr($this->id) . '-card-number">' . esc_html__('Card Number', 'woocommerce') . ' <span class="required">*</span></label>
 
 				<iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
-                        src="https://cdn.cardknox.com/ifields/2.15.2405.1601/ifield.htm?" + "' . esc_attr($timestamp) . '" frameBorder="0" width="100%"
+                        src="https://cdn.cardknox.com/ifields/3.0.2503.2101/ifield.htm?" + "' . esc_attr($timestamp) . '" frameBorder="0" width="100%"
                         height="55"></iframe>
 			</p> <input data-ifields-id="card-number-token" name="xCardNum" id="cardknox-card-number" type="hidden"/>',
             'card-expiry-field' => '<p class="form-row form-row-first" style=" margin: 0 !important;">
@@ -415,8 +415,7 @@ class WC_Gateway_Cardknox extends WC_Payment_Gateway_CC
         );
 
         $suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '' : '.min';
-
-        wp_enqueue_script('cardknox', 'https://cdn.cardknox.com/ifields/2.15.2401.3101/ifields.min.js', '', '1.0.0', false);
+        wp_enqueue_script('cardknox', 'https://cdn.cardknox.com/ifields/3.0.2503.2101/ifields.min.js', '', '1.0.0', false);
         wp_enqueue_script('woocommerce_cardknox', plugins_url('assets/js/cardknox' . $suffix . '.js', WC_CARDKNOX_MAIN_FILE), array('jquery-payment'), filemtime(plugin_dir_path(dirname(__FILE__)) . 'assets/js/cardknox' . $suffix . '.js'), true);
         
 

--- a/woocommerce-gateway-cardknox.php
+++ b/woocommerce-gateway-cardknox.php
@@ -4,7 +4,7 @@ Plugin Name: WooCommerce Cardknox Gateway
 Description: Accept credit card payments on your store using the Cardknox gateway.
 Author: Cardknox Development Inc.
 Author URI: https://www.cardknox.com/
-Version: 1.2.72
+Version: 1.2.73
 Requires at least: 4.4
 Tested up to: 6.7.1
 WC requires at least: 2.5
@@ -36,7 +36,7 @@ if (!defined('ABSPATH')) {
 /**
  * Required minimums and constants
  */
-define('WC_CARDKNOX_VERSION', '1.2.72');
+define('WC_CARDKNOX_VERSION', '1.2.73');
 define('WC_CARDKNOX_MIN_PHP_VER', '5.6.0');
 define('WC_CARDKNOX_MIN_WC_VER', '2.5.0');
 define('WC_CARDKNOX_MAIN_FILE', __FILE__);
@@ -576,7 +576,7 @@ if (!class_exists('WC_Cardknox')) :
             $applePay_quickcheckout = isset($applePayoptions['applepay_quickcheckout']) ? $applePayoptions['applepay_quickcheckout'] : 'no';
 
             if (is_cart()) {
-                wp_enqueue_script('cardknox', 'https://cdn.cardknox.com/ifields/2.15.2309.2601/ifields.min.js', '', '1.0.0', false);
+                wp_enqueue_script('cardknox', 'https://cdn.cardknox.com/ifields/3.0.2503.2101/ifields.min.js', '', '1.0.0', false);
             }
 
             if (is_cart() && $googlepay_quickcheckout == 'no') {


### PR DESCRIPTION
Change the ifield version old to new like **2.15.2405.1601 to 3.0.2503.2101**.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update iFields version to 3.0.2503.2101 and bump plugin version to 1.2.73 in Cardknox WooCommerce gateway.
> 
>   - **iFields Version Update**:
>     - Updated iFields version from `2.15.2405.1601` to `3.0.2503.2101` in `class-wc-gateway-cardknox-googlepay.php`, `class-wc-gateway-cardknox.php`, and `woocommerce-gateway-cardknox.php`.
>     - Affects iframe `src` attributes and script URLs.
>   - **Version Bump**:
>     - Updated plugin version to `1.2.73` in `woocommerce-gateway-cardknox.php` and `constants` in the same file.
>   - **Changelog**:
>     - Added entry for version `1.2.73` in `changelog.md` noting the iFields update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fwoocommerce-gateway-cardknox&utm_source=github&utm_medium=referral)<sup> for 8abe8f606622f25c24438bd8ad1777cedc603fb6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->