### PR TITLE
PLGN-170 - remove notice issue after WP version 6.8 updated

### DIFF
--- a/woocommerce-gateway-cardknox.php
+++ b/woocommerce-gateway-cardknox.php
@@ -156,7 +156,7 @@ if (!class_exists('WC_Cardknox')) :
             add_action('wp_ajax_nopriv_applepay_cardknox_create_order', array($this, 'applepayCardknoxCreateorder'));
         }
         /*
-        *   Initalize the plugin functionality as per the standard
+         * Initialize the plugin functionality as per the standard
         */
         public function init_plugin() {
             if (self::get_environment_warning()) {

--- a/woocommerce-gateway-cardknox.php
+++ b/woocommerce-gateway-cardknox.php
@@ -184,9 +184,7 @@ if (!class_exists('WC_Cardknox')) :
             add_action('woocommerce_order_status_on-hold_to_refunded', array($this, 'refund_payment'));
             add_action('woocommerce_order_status_processing_to_cancelled', array($this, 'refund_payment'));
             add_action('woocommerce_order_status_processing_to_completed', array($this, 'capture_payment'));
-        
             $this->settingPage = 'admin.php?page=wc-settings&tab=checkout&section=';
-        
             add_action('wp_ajax_nopriv_get_data', array($this, 'threedsAjaxHandler'));
             add_action('wp_ajax_get_data', array($this, 'threedsAjaxHandler'));
         }
@@ -386,7 +384,6 @@ if (!class_exists('WC_Cardknox')) :
             if (class_exists('WC_Subscriptions_Order') && function_exists('wcs_create_renewal_order')) {
                 $this->subscription_support_enabled = true;
             }
-        
             if (class_exists('WC_Pre_Orders_Order')) {
                 $this->pre_order_enabled = true;
             }


### PR DESCRIPTION
The notice-level issue has been resolved in WordPress 6.8. Compatibility has also been verified with WordPress version 6.7.2, and no related issues were found.

![image](https://github.com/user-attachments/assets/e930d759-095f-408e-83ac-b7f775e98186)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes notice-level issue in WooCommerce Cardknox Gateway by modifying plugin initialization for WordPress 6.8 compatibility.
> 
>   - **Behavior**:
>     - Resolves notice-level issue in WordPress 6.8 by modifying plugin initialization.
>     - Verifies compatibility with WordPress 6.7.2.
>   - **Functions**:
>     - Renames `init()` to `init_plugin()` and changes hook from `plugins_loaded` to `init` in `woocommerce-gateway-cardknox.php`.
>     - Separates `init_gateways()` call for better code organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fwoocommerce-gateway-cardknox&utm_source=github&utm_medium=referral)<sup> for d17c39a7d8dc8889a9dc5121370fbe57b6792913. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->