### PR TITLE
PLGN-178 Incompatible plugin detected issue resolved

### DIFF
--- a/woocommerce-gateway-cardknox.php
+++ b/woocommerce-gateway-cardknox.php
@@ -1017,6 +1017,21 @@ if (!class_exists('WC_Cardknox')) :
             die();
         }
     }
+
+    /*
+       Declare compatibility with WooCommerce HPOS
+    */
+    add_action('before_woocommerce_init', function() {
+        if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+                'custom_order_tables',
+                __FILE__,
+                true
+            );
+        }
+    });
+
+
     $GLOBALS['wc_cardknox'] = WC_Cardknox::get_instance();
 
 endif;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/434e05d4-bfb8-4e6f-bd7d-86a69f8f5c93)

The issue is fixed.

Note: This issue appears because WooCommerce's new High-Performance Order Storage (HPOS) uses custom tables for orders, but your Cardknox Gateway plugin is not marked as compatible with HPOS. WooCommerce flags it to prevent potential order processing issues if the plugin uses old wp_posts structures or direct SQL queries for orders.

![image](https://github.com/user-attachments/assets/d6e401ab-28dd-4d91-a73c-4c93baec59c9)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Declare compatibility with WooCommerce HPOS in Cardknox Gateway plugin to resolve incompatible plugin issue.
> 
>   - **Compatibility**:
>     - Declares compatibility with WooCommerce HPOS by adding a hook in `woocommerce-gateway-cardknox.php`.
>     - Uses `\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility` to mark the plugin as compatible with `custom_order_tables`.
>   - **Misc**:
>     - Adds a new action `before_woocommerce_init` to handle compatibility declaration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fwoocommerce-gateway-cardknox&utm_source=github&utm_medium=referral)<sup> for 58a1c6672547092d3e065977f48be41f54536377. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

